### PR TITLE
catch2: Version bump to 2.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The contents of this GIT repository are completely separate from the software be
 
 ### License(s) for packaged software:
 
-    ~/.conan/data/catch2/2.2.0/bincrafters/package/<random_package_id>/licenses/LICENSE.txt
+    ~/.conan/data/catch2/2.4.2/bincrafters/package/<random_package_id>/licenses/LICENSE.txt
 
 *Note :   The most common filenames for OSS licenses are `LICENSE` AND `COPYING` without file extensions.*
 
 ### License for Bincrafters recipe:
 
-    ~/.conan/data/catch2/2.1.0/bincrafters/export/LICENSE.md
+    ~/.conan/data/catch2/2.4.2/bincrafters/export/LICENSE.md

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import tempfile
 
 class Catch2Conan(ConanFile):
     name = "catch2"
-    version = "2.4.1"
+    version = "2.4.2"
     description = "A modern, C++-native, header-only, framework for unit-tests, TDD and BDD"
     homepage = "https://github.com/catchorg/Catch2"
     url = "https://github.com/bincrafters/conan-catch"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-find_package(Catch2 2.4.0 REQUIRED CONFIG)
+find_package(Catch2 2.4.2 REQUIRED CONFIG)
 
 include(ParseAndAddCatchTests)
 include(Catch)


### PR DESCRIPTION
Since Github does not allow targeting a branch which does not exist yet, I hope you will create the required branches so I may resubmit this PR ASAP, since catch2 v2.4.2 is required for my current project.